### PR TITLE
Add placeholder visuals to blog index

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
+import { generatePlaceholder } from '../utils/placeholder';
 
 // Get all blog posts, sorted by date
 const posts = await getCollection('blog', ({ data }) => {
@@ -16,31 +17,42 @@ const posts = await getCollection('blog', ({ data }) => {
 >
   <div class="space-y-16">
     {posts.map(post => (
-      <article class="post-card">
-        <a href={`/blog/${post.slug}`} class="block group">
-          <h2 class="post-title group-hover:text-primary transition-colors">
-            {post.data.title}
-          </h2>
-          
-          {post.data.subtitle && (
-            <h3 class="post-subtitle mt-2">
-              {post.data.subtitle}
-            </h3>
-          )}
-        </a>
-        
-        <div class="mt-4">
-          <p class="text-[rgba(0,0,0,0.8)]">
-            {post.body.length > 300 
-              ? post.body.substring(0, 300).replace(/[#*`]/g, '').trim() + '...'
-              : post.body.replace(/[#*`]/g, '').trim()}
-          </p>
-          <p class="mt-4">
-            <a href={`/blog/${post.slug}`} class="read-more-btn">
-              READ&nbsp;MORE
-            </a>
-          </p>
+      <article class="post-card md:flex md:items-start md:justify-between">
+        <div class="flex-1">
+          <a href={`/blog/${post.slug}`} class="block group">
+            <h2 class="post-title group-hover:text-primary transition-colors">
+              {post.data.title}
+            </h2>
+
+            {post.data.subtitle && (
+              <h3 class="post-subtitle mt-2">
+                {post.data.subtitle}
+              </h3>
+            )}
+          </a>
+
+          <div class="mt-4">
+            <p class="text-[rgba(0,0,0,0.8)]">
+              {post.body.length > 300
+                ? post.body.substring(0, 300).replace(/[#*`]/g, '').trim() + '...'
+                : post.body.replace(/[#*`]/g, '').trim()}
+            </p>
+            <p class="mt-4">
+              <a href={`/blog/${post.slug}`} class="read-more-btn">
+                READ&nbsp;MORE
+              </a>
+            </p>
+          </div>
         </div>
+        <img
+          src={generatePlaceholder(post.data.title)}
+          alt={`Illustration for ${post.data.title}`}
+          class="post-thumb mt-4 md:mt-0 md:ml-6"
+          loading="lazy"
+          decoding="async"
+          width="160"
+          height="90"
+        />
       </article>
     ))}
   </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,10 @@
     @apply border-b border-[rgba(0,0,0,0.1)] mb-10 pb-10 relative;
   }
 
+  .post-thumb {
+    @apply w-40 h-24 object-cover flex-none rounded;
+  }
+
   .post-title {
     @apply text-lg leading-relaxed text-gray-800 hover:text-gray-900;
   }
@@ -62,6 +66,9 @@
   }
 
   @screen md {
+    .post-card {
+      @apply flex;
+    }
     .post-title {
       @apply text-xl leading-tight font-medium text-gray-800 hover:text-gray-900;
     }

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -1,0 +1,18 @@
+/**
+ * Generate a lightweight placeholder image for a blog post.
+ * The image is an SVG data URI containing the first letter of the title.
+ * Colors are derived from the title so each post gets a unique visual.
+ *
+ * @param title Post title used to derive the placeholder.
+ * @returns Data URI string representing the SVG image.
+ */
+export function generatePlaceholder(title: string): string {
+  const hue = Array.from(title).reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 360;
+  const color = `hsl(${hue}, 70%, 80%)`;
+  const first = title.trim()[0] ?? '';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90">
+    <rect width="100%" height="100%" fill="${color}"/>
+    <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="48" fill="#555">${first}</text>
+  </svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+}


### PR DESCRIPTION
## Summary
- add a small helper that generates SVG placeholders
- display a placeholder image to the right of each post
- style new `post-thumb` image class and flex layout

## Testing
- `bun run build` *(fails: astro command not found)*