### PR TITLE
Increase post images and add placeholder generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "generate:images": "node scripts/generate-images.mjs",
     "lighthouse": "npm run build && npx serve -s dist -l 8080 & npx wait-on http://localhost:8080 && npx lighthouse http://localhost:8080 --chrome-flags=\"--headless --no-sandbox\" --view && pkill -f \"serve -s dist\""
   },
   "dependencies": {

--- a/public/img/posts/hello-world.svg
+++ b/public/img/posts/hello-world.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="288" height="192"><rect width="100%" height="100%" fill="hsl(49, 70%, 80%)"/><text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="96" fill="#555">H</text></svg>

--- a/public/img/posts/reading-list.svg
+++ b/public/img/posts/reading-list.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="288" height="192"><rect width="100%" height="100%" fill="hsl(356, 70%, 80%)"/><text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="96" fill="#555">M</text></svg>

--- a/public/img/posts/technology-stacks.svg
+++ b/public/img/posts/technology-stacks.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="288" height="192"><rect width="100%" height="100%" fill="hsl(293, 70%, 80%)"/><text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="96" fill="#555">T</text></svg>

--- a/scripts/generate-images.mjs
+++ b/scripts/generate-images.mjs
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+function generatePlaceholder(title) {
+  const hue = Array.from(title).reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 360;
+  const color = `hsl(${hue}, 70%, 80%)`;
+  const first = title.trim()[0] ?? '';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="288" height="192"><rect width="100%" height="100%" fill="${color}"/><text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="96" fill="#555">${first}</text></svg>`;
+  return svg;
+}
+
+async function run() {
+  const postsDir = path.join('src', 'content', 'blog');
+  const outDir = path.join('public', 'img', 'posts');
+  await fs.mkdir(outDir, { recursive: true });
+  const files = await fs.readdir(postsDir);
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const filePath = path.join(postsDir, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    const match = content.match(/title:\s*(.+)/);
+    const title = match ? match[1].replace(/^"|"$/g, '').trim() : path.basename(file, '.md');
+    const slug = path.basename(file, '.md');
+    const svg = generatePlaceholder(title);
+    await fs.writeFile(path.join(outDir, slug + '.svg'), svg);
+  }
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { generatePlaceholder } from '../utils/placeholder';
 
 // Get all blog posts, sorted by date
 const posts = await getCollection('blog', ({ data }) => {
@@ -45,13 +44,13 @@ const posts = await getCollection('blog', ({ data }) => {
           </div>
         </div>
         <img
-          src={generatePlaceholder(post.data.title)}
+          src={`/img/posts/${post.slug}.svg`}
           alt={`Illustration for ${post.data.title}`}
           class="post-thumb mt-4 md:mt-0 md:ml-6"
           loading="lazy"
           decoding="async"
-          width="160"
-          height="90"
+          width="288"
+          height="192"
         />
       </article>
     ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,7 +40,7 @@
   }
 
   .post-thumb {
-    @apply w-40 h-24 object-cover flex-none rounded;
+    @apply w-72 h-48 object-cover flex-none rounded;
   }
 
   .post-title {

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -10,9 +10,9 @@ export function generatePlaceholder(title: string): string {
   const hue = Array.from(title).reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 360;
   const color = `hsl(${hue}, 70%, 80%)`;
   const first = title.trim()[0] ?? '';
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90">
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="288" height="192">
     <rect width="100%" height="100%" fill="${color}"/>
-    <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="48" fill="#555">${first}</text>
+    <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-family="sans-serif" font-size="96" fill="#555">${first}</text>
   </svg>`;
   return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
 }


### PR DESCRIPTION
## Summary
- resize placeholder SVG generator to 288x192
- enlarge `.post-thumb` styles
- load pregenerated images on the index page
- add a script to generate placeholder images for each post

## Testing
- `npm run generate:images`