### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +28,9 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "latest"
+          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -8,6 +8,10 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+concurrency:
+  group: "pagespeed"
+  cancel-in-progress: true
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
@@ -68,7 +72,7 @@ jobs:
           fi
 
       - name: Upload Lighthouse report
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report
           path: ./lhreport.json


### PR DESCRIPTION
## Summary
- improve Bun setup in `gh-pages.yml`
- add concurrency group for page deployment
- add concurrency group for the PageSpeed workflow
- use major version of `actions/upload-artifact`

## Testing
- `bun run build` *(fails: astro: command not found)*