### PR TITLE
Add Modern MLOps 2025 blog post

### DIFF
--- a/src/content/blog/modern-mlops-2025.md
+++ b/src/content/blog/modern-mlops-2025.md
@@ -1,0 +1,71 @@
+---
+title: "💫 Modern MLOps in 2025 — A Concise Guide"
+subtitle: "A lightning-quick overview of what MLOps is and how today’s most-used tools such as Feast and MLflow 3.0 fit together."
+publishDate: 2025-06-11
+tags: ["mlops", "mlflow", "feast", "kubeflow", "flyte", "feature-store", "ci/cd", "observability"]
+---
+
+> **TL;DR** — MLOps = DevOps + ML-specific needs (data/experiment tracking, automated retraining, online serving, and continuous monitoring).  
+> A pragmatic 2025 stack couples **Feast** for features, **MLflow 3.0** for experiments & registry, and an orchestrator (e.g. **Flyte** or **Kubeflow**) wrapped with standard CI/CD and observability.
+
+## 🌐 What is MLOps?
+
+MLOps (Machine-Learning Operations) is the engineering discipline that scales a model from a notebook to 24×7 production.
+It glues **data**, **model code**, **infrastructure**, and **people** together so that:
+
+* models are _repeatable_ (same inputs ➜ same outputs)
+* releases are _automated_ (CI/CD pipelines not screenshots)
+* behaviour is _observable_ (metrics, drift, feedback loops)
+
+A 2025 survey lists **90+** active OSS & SaaS tools, grouped into feature stores, experiment trackers, orchestration, deployment, and monitoring stages.
+
+![Illustration – The MLOps lifecycle: data → training → evaluation → deployment → monitoring (OpenAI style)](/illustrations/mlops-lifecycle.png)
+*An end-to-end MLOps loop.*
+
+## 🧩 Key Building Blocks & Popular Tools
+
+| Stage | Responsibility | 2025 Favourites (OSS ▲ / Hosted ◆) |
+|-------|---------------|-------------------------------------|
+| **Data / Features** | Keep training & serving features consistent | ▲ **Feast**, ▲ Hopsworks, ◆ Vertex AI Feature Store |
+| **Experiment Tracking** | Log params + metrics + artifacts | ▲ **MLflow 3.0**, ▲ Weights & Biases, ▲ Neptune |
+| **Workflow Orchestration** | Declare pipelines, manage DAGs | ▲ Flyte, ▲ Kubeflow Pipelines, ▲ Apache Airflow |
+| **CI/CD & Infra-as-Code** | Automate build, test, deploy | ▲ GitHub Actions, ▲ Terraform, ◆ AWS CodePipeline |
+| **Model Serving** | Real-time / batch inference | ▲ KServe, ▲ BentoML, ◆ AWS SageMaker |
+| **Observability & Drift** | Detect performance regressions | ▲ Evidently AI, ▲ Prometheus + Grafana, ◆ Arize |
+
+### Focus tools
+
+**Feast (Feature Store)** – provides a versioned offline store, a low-latency online store and a gRPC/HTTP feature server so the same features feed both training and inference.
+
+![Illustration – Feast serving the same feature vectors to training jobs (batch) and live micro-services (realtime).](/illustrations/feast-dual-store.png)
+*Feast bridges offline ↔ online features.*
+
+**MLflow 3.0 (Preview)** – adds automatic experiment tracking, a richer model registry, and built-in evaluation for classic ML _and_ generative-AI workloads.
+
+![Illustration – MLflow experiment timeline showing runs, parameters and artifacts (OpenAI style).](/illustrations/mlflow-runs.png)
+*MLflow 3.0 unifies tracking & registry.*
+
+## 🛠️ A Minimal 2025 Stack in Practice
+
+```mermaid
+flowchart LR
+  subgraph Data Plane
+    source(["Data Lake / Warehouse"])
+    feast_offline["Feast Offline Store (DuckDB/Snowflake)"]
+    feast_online["Feast Online Store (Redis/Cassandra)"]
+  end
+  subgraph Train
+    flyte_task["Flyte Task: Train.py"]
+    mlflow_runs["MLflow Run + Evaluation"]
+  end
+  subgraph Serve
+    kserve["KServe Inference Service"]
+    grafana["Grafana / Prometheus"]
+  end
+
+  source --> feast_offline --> flyte_task
+  feast_online --> kserve
+  flyte_task --> mlflow_runs
+  mlflow_runs --> kserve
+  kserve --> grafana
+```


### PR DESCRIPTION
## Summary
- add a blog post on a modern MLOps stack in 2025

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4e554a883209b2f6b054b3337b1