### PR TITLE
Fix Actions deployment failure

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Create .nojekyll file
         run: touch ./dist/.nojekyll
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to include configure-pages step before upload

## Testing
- `bun run build` *(fails: astro not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ac8bafa90832085776b5465945853