### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,14 +32,14 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build site
         run: npm run build
-
-      - name: Create .nojekyll file
-        run: touch ./dist/.nojekyll
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -1,1 +1,26 @@
-{\n  "name": "cityhunteur-blog",\n  "version": "0.0.1",\n  "type": "module",\n  "scripts": {\n    "dev": "astro dev",\n    "start": "astro dev",\n    "build": "astro build",\n    "preview": "astro preview",\n    "astro": "astro",\n    "test": "echo \"No tests specified\" && exit 0"\n  },\n  "dependencies": {\n    "astro": "latest",\n    "@fontsource/ibm-plex-sans": "latest",\n    "@fontsource/ibm-plex-mono": "latest",\n    "@fontsource/ia-writer-quattro": "latest"\n  },\n  "devDependencies": {\n    "@astrojs/sitemap": "latest"\n  },\n  "engines": {\n    "node": ">=18.17 <23"\n  },\n  "packageManager": "npm@10"\n}
+{
+  "name": "cityhunteur-blog",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "astro": "latest",
+    "@fontsource/ibm-plex-sans": "latest",
+    "@fontsource/ibm-plex-mono": "latest",
+    "@fontsource/ia-writer-quattro": "latest"
+  },
+  "devDependencies": {
+    "@astrojs/sitemap": "latest"
+  },
+  "engines": {
+    "node": ">=18.17 <23"
+  },
+  "packageManager": "npm@10"
+}


### PR DESCRIPTION
## Summary
- add concurrency group and setup-pages step to gh-pages workflow for GitHub Pages deployment
- fix malformed package.json so npm can parse and run tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f047576c832097d58560fc074f99