### PR TITLE
ci: retire duplicate GH Pages workflow in favor of CICD

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,10 +1,7 @@
-name: Deploy to GitHub Pages
+name: Deploy to GitHub Pages (manual)
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  push:
-    branches: [ main ]
-  # Allow you to run this workflow manually from the Actions tab on GitHub.
+  # Manual trigger only to avoid duplication with CICD
   workflow_dispatch:
 
 # Allow this job to clone the repo and create a page deployment
@@ -30,13 +27,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build site
         run: npm run build


### PR DESCRIPTION
This change:

- Keeps  as a manual-only fallback (workflow_dispatch)
- Removes npm cache and switches to 
added 2 packages, changed 6 packages, and audited 298 packages in 6s

145 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities (no lockfile) for manual runs
- Avoids duplicate deploy runs and cross-workflow cancellations with CICD

CICD remains the single source of truth for lint, test, build, Lighthouse gating, and deploy on .

Once merged, future pushes to  will only use CICD for deployment.