### PR TITLE
feat(news): add full-bleed news layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Blog Archive
 
-This site is built with [Astro 4](https://astro.build/) and a custom CSS stack. It showcases an archive list layout inspired by iA's Writer while using my own content and neutral branding.
+This site is built with [Astro 4](https://astro.build/) and a custom CSS stack. It showcases an archive list layout and a News page of full‑bleed hero sections inspired by iA's News feed while using my own content and neutral branding.
 
 ## Local Development
 
@@ -23,10 +23,11 @@ Both fonts load with `font-display: swap` to limit layout shift.
 ## Project Structure
 
 - `src/styles/` – design tokens and global styles
-- `src/layouts/` – `BaseLayout` wrapper
-- `src/components/` – `PostRow` for the archive list
+- `src/layouts/` – `BaseLayout` and `NewsLayout` wrappers
+- `src/components/` – `PostRow` and `NewsSection` components
 - `src/content/posts/` – markdown posts with frontmatter
-- `src/pages/` – index and dynamic article routes
+- `src/content/news/` – news entries for the News page
+- `src/pages/` – index, News index, and dynamic article routes
 
 ## License
 

--- a/src/components/NewsSection.astro
+++ b/src/components/NewsSection.astro
@@ -1,0 +1,87 @@
+---
+export interface Theme {
+  background: string;
+  textColor: string;
+  accentColor: string;
+  imagePosition?: 'right' | 'bottom';
+}
+export interface Props {
+  category: string;
+  title: string;
+  tagline: string;
+  ctaText: string;
+  ctaUrl: string;
+  image: string;
+  alt?: string;
+  theme: Theme;
+}
+const { category, title, tagline, ctaText, ctaUrl, image, alt = title, theme } = Astro.props;
+---
+<section class="section" style={`--section-bg:${theme.background}; --section-text:${theme.textColor}; --section-accent:${theme.accentColor};`}>
+  <div class:list={["section-inner", theme.imagePosition === 'right' ? 'is-right' : 'is-bottom']}>
+    <div class="section-content">
+      <p class="label">{category}</p>
+      <h2 class="headline">{title}</h2>
+      <p class="tagline">{tagline}</p>
+      <a href={ctaUrl} class="cta">{ctaText}</a>
+    </div>
+    <img src={image} alt={alt} loading="lazy" class="illustration" />
+  </div>
+</section>
+
+<style>
+.section-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--section-gap);
+  max-width: var(--container-max);
+  margin-inline: auto;
+}
+.section-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--section-gap);
+}
+.is-right {
+  flex-direction: row;
+  text-align: left;
+}
+.is-right .section-content {
+  align-items: flex-start;
+}
+.is-right .illustration {
+  flex: 1;
+}
+.is-right .section-content {
+  flex: 1;
+}
+.label {
+  font-size: var(--label-size);
+  letter-spacing: var(--label-tracking);
+  text-transform: uppercase;
+}
+.headline {
+  font-size: var(--h1-size);
+  line-height: var(--lh-tight);
+}
+.tagline {
+  font-size: var(--h2-size);
+  line-height: var(--lh-body);
+}
+.illustration {
+  width: 100%;
+  height: auto;
+}
+@media (max-width: 900px) {
+  .is-right {
+    flex-direction: column;
+    text-align: center;
+  }
+  .is-right .section-content {
+    align-items: center;
+  }
+}
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,7 +10,26 @@ const posts = defineCollection({
   }),
 });
 
+const news = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    slug: z.string().optional(),
+    date: z.date(),
+    category: z.string(),
+    tagline: z.string(),
+    image: z.string(),
+    theme: z.object({
+      background: z.string(),
+      textColor: z.string(),
+      accentColor: z.string(),
+      imagePosition: z.enum(['right', 'bottom']).optional(),
+    }),
+  }),
+});
+
 export const collections = {
   posts,
+  news,
 };
 

--- a/src/content/news/designing-with-rhythm.md
+++ b/src/content/news/designing-with-rhythm.md
@@ -1,0 +1,14 @@
+---
+title: Designing with Rhythm
+slug: designing-with-rhythm
+date: 2024-05-01
+category: Insights
+tagline: Exploring visual cadence in modern layouts.
+image: https://picsum.photos/seed/rhythm/1200/800
+theme:
+  background: "#000000"
+  textColor: "#ffffff"
+  accentColor: "#7454f6"
+  imagePosition: right
+---
+Design systems thrive on rhythm. In this short note I document experiments with spacing and tempo that make interfaces feel musical.

--- a/src/content/news/focus-mode.md
+++ b/src/content/news/focus-mode.md
@@ -1,0 +1,14 @@
+---
+title: Focus Mode
+slug: focus-mode
+date: 2024-03-20
+category: Presenter
+tagline: Hiding the noise to write better.
+image: https://picsum.photos/seed/focus/1200/800
+theme:
+  background: "#000000"
+  textColor: "#ffffff"
+  accentColor: "#7454f6"
+  imagePosition: bottom
+---
+Notes on designing a distraction-free screen that still feels alive.

--- a/src/content/news/micro-interactions.md
+++ b/src/content/news/micro-interactions.md
@@ -1,0 +1,14 @@
+---
+title: Micro Interactions
+slug: micro-interactions
+date: 2024-02-10
+category: Insights
+tagline: Tiny details with outsized charm.
+image: https://picsum.photos/seed/micro/1200/800
+theme:
+  background: "#eef8ff"
+  textColor: "#111111"
+  accentColor: "#0094ff"
+  imagePosition: bottom
+---
+How small animations guide users without shouting.

--- a/src/content/news/night-shift.md
+++ b/src/content/news/night-shift.md
@@ -1,0 +1,14 @@
+---
+title: Night Shift
+slug: night-shift
+date: 2024-01-05
+category: Notebook
+tagline: Designing for late-night reading.
+image: https://picsum.photos/seed/night/1200/800
+theme:
+  background: "#000000"
+  textColor: "#ffffff"
+  accentColor: "#7454f6"
+  imagePosition: bottom
+---
+Dark palettes can calm the mind when the sun is gone.

--- a/src/content/news/pastel-interfaces.md
+++ b/src/content/news/pastel-interfaces.md
@@ -1,0 +1,14 @@
+---
+title: Pastel Interfaces
+slug: pastel-interfaces
+date: 2024-04-15
+category: Notebook
+tagline: Soft colors that still pop.
+image: https://picsum.photos/seed/pastel/1200/800
+theme:
+  background: "#fdf2f8"
+  textColor: "#111111"
+  accentColor: "#0094ff"
+  imagePosition: bottom
+---
+A quick sketch on balancing gentle hues with strong typography.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,10 @@ export interface Props {
   font?: 'ibm' | 'ia';
 }
 const { title = "Pravin Goomannee's Blog", font = 'ibm' } = Astro.props;
+if (font === 'ia') {
+  await import('@fontsource/ia-writer-quattro/400.css');
+  await import('@fontsource/ia-writer-quattro/700.css');
+}
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/src/layouts/NewsLayout.astro
+++ b/src/layouts/NewsLayout.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import type { Props as BaseProps } from './BaseLayout.astro';
+export interface Props extends BaseProps {}
+const { title = 'News', font = 'ibm' } = Astro.props;
+---
+<BaseLayout title={title} font={font}>
+  <span slot="breadcrumbs">News</span>
+  <slot />
+</BaseLayout>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -1,0 +1,33 @@
+---
+import NewsLayout from '@/layouts/NewsLayout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('news');
+  return posts.map(post => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { title, category, image, tagline } = post.data;
+const { Content } = await post.render();
+---
+<NewsLayout title={title}>
+  <article>
+    <p class="overline">{category}</p>
+    <h1>{title}</h1>
+    <img src={image} alt={tagline} loading="lazy" />
+    <Content />
+  </article>
+</NewsLayout>
+
+<style>
+article img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  margin-bottom: 1em;
+}
+</style>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,0 +1,27 @@
+---
+import NewsLayout from '@/layouts/NewsLayout.astro';
+import NewsSection from '@/components/NewsSection.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('news')).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+const fallbacks = [
+  { background: '#000000', textColor: '#ffffff', accentColor: '#7454f6', imagePosition: 'right' },
+  { background: '#f5f5f5', textColor: '#111111', accentColor: '#0094ff', imagePosition: 'bottom' },
+];
+function pickTheme(theme, index) {
+  return theme ?? fallbacks[index % fallbacks.length];
+}
+---
+<NewsLayout title="News">
+  {posts.map((post, i) => (
+    <NewsSection
+      category={post.data.category}
+      title={post.data.title}
+      tagline={post.data.tagline}
+      ctaText="READ ARTICLE"
+      ctaUrl={`/news/${post.slug}/`}
+      image={post.data.image}
+      theme={pickTheme(post.data.theme, i)}
+    />
+  ))}
+</NewsLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -113,3 +113,27 @@ p {
   aspect-ratio: 3 / 4;
   object-fit: cover;
 }
+
+/* News sections */
+.section {
+  width: 100vw;
+  margin-inline: calc(50% - 50vw);
+  padding: var(--section-pad);
+  background: var(--section-bg, var(--light-bg));
+  color: var(--section-text, var(--text-dark));
+}
+
+.cta {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: var(--section-accent, var(--link));
+  color: var(--text-light);
+  font-weight: 700;
+  text-decoration: none;
+  transition: filter 0.2s;
+}
+
+.cta:hover {
+  filter: brightness(0.9);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -24,5 +24,18 @@
 
   /* Label */
   --label-tracking: 0.06em;
+
+  /* News sections */
+  --section-pad: clamp(4rem, 8vw, 8rem);
+  --section-gap: clamp(1rem, 3vw, 2rem);
+  --h1-size: clamp(2.5rem, 6vw, 3.75rem);
+  --h2-size: clamp(1.125rem, 1vw + 1rem, 1.375rem);
+  --label-size: clamp(0.75rem, 0.2vw + 0.7rem, 0.875rem);
+  --dark-bg: #000000;
+  --light-bg: #f5f5f5;
+  --text-dark: #111111;
+  --text-light: #ffffff;
+  --accent-purple: #7454f6;
+  --accent-blue: #0094ff;
 }
 


### PR DESCRIPTION
## Summary
- style tokens and global classes for full-bleed hero sections and CTA buttons
- add reusable NewsSection component and NewsLayout wrapper
- introduce `news` content collection with example entries and pages

## Testing
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68c719aebda08320b682b70985a868e9